### PR TITLE
Fix message input sending during IME composition

### DIFF
--- a/packages/web-ui/components/chat/message-input.tsx
+++ b/packages/web-ui/components/chat/message-input.tsx
@@ -21,8 +21,8 @@ export function MessageInput({ onSend, disabled = false }: MessageInputProps) {
   }
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    // Send message on Enter (without Shift)
-    if (e.key === 'Enter' && !e.shiftKey) {
+    // Send message on Enter (without Shift), but not during IME composition
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault()
       handleSend()
     }


### PR DESCRIPTION
## Summary
Fixed an issue where messages could be sent prematurely while using Input Method Editor (IME) composition, such as when typing in Chinese, Japanese, or Korean languages.

## Issue
https://github.com/shomrkm/shochan_ai/issues/21

## Changes
- Added `!e.nativeEvent.isComposing` check to the Enter key handler in `MessageInput` component
- This prevents the send action from triggering while the user is actively composing characters through an IME

## Details
The `isComposing` property on the native keyboard event indicates whether the user is in the middle of composing text with an IME. By checking this flag, we ensure that pressing Enter during composition completes the character input rather than sending an incomplete message. This is a common UX pattern for applications that support international text input.

https://claude.ai/code/session_016WHMAQ86CTCR8S5ZEb56Gz