### PR TITLE
fix: preserve conversation context across multi-turn messages

### DIFF
--- a/packages/web-ui/components/chat/chat-interface.tsx
+++ b/packages/web-ui/components/chat/chat-interface.tsx
@@ -94,7 +94,7 @@ export function ChatInterface() {
     }
 
     setMessages((prev) => [...prev, userMessage])
-    mutation.mutate(content)
+    mutation.mutate({ message: content, conversationId })
   }
 
   return (

--- a/packages/web-ui/lib/api/hooks/use-send-message.ts
+++ b/packages/web-ui/lib/api/hooks/use-send-message.ts
@@ -1,7 +1,12 @@
 import { useMutation, type UseMutationOptions } from '@tanstack/react-query'
 import type { SendMessageResponse } from '@/types/chat'
 
-async function sendMessage(message: string): Promise<SendMessageResponse> {
+interface SendMessageArgs {
+  message: string
+  conversationId?: string | null
+}
+
+async function sendMessage({ message, conversationId }: SendMessageArgs): Promise<SendMessageResponse> {
   const apiUrl = process.env.NEXT_PUBLIC_API_URL
   const endpoint = `${apiUrl}/api/agent/query`
 
@@ -10,7 +15,7 @@ async function sendMessage(message: string): Promise<SendMessageResponse> {
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ message }),
+    body: JSON.stringify({ message, conversationId }),
   })
 
   if (!response.ok) {
@@ -22,7 +27,7 @@ async function sendMessage(message: string): Promise<SendMessageResponse> {
 }
 
 type UseSendMessageOptions = Omit<
-  UseMutationOptions<SendMessageResponse, Error, string>,
+  UseMutationOptions<SendMessageResponse, Error, SendMessageArgs>,
   'mutationFn'
 >
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -27,7 +27,8 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
-    "redis": "^4.7.0"
+    "redis": "^4.7.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/packages/web/src/routes/agent.test.ts
+++ b/packages/web/src/routes/agent.test.ts
@@ -155,6 +155,25 @@ describe('Agent Routes', () => {
 			expect(thread?.events).toHaveLength(1);
 		});
 
+		it('should create new conversation when conversationId is null', async () => {
+			mockGenerateNextToolCall.mockResolvedValueOnce(null);
+
+			const response = await request(app)
+				.post('/api/agent/query')
+				.send({ message: 'Test message', conversationId: null })
+				.expect(200);
+
+			// null conversationId should be treated as omitted, a new conversation is created
+			expect(response.body.conversationId).toMatch(
+				/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+			);
+
+			await new Promise((resolve) => setTimeout(resolve, 2500));
+
+			const thread = await redisStore.get(response.body.conversationId);
+			expect(thread?.events).toHaveLength(1);
+		});
+
 		it('should return 400 when message is missing', async () => {
 			const response = await request(app)
 				.post('/api/agent/query')

--- a/packages/web/src/routes/agent.ts
+++ b/packages/web/src/routes/agent.ts
@@ -56,22 +56,11 @@ export function createAgentRouter(deps: AgentDependencies): Router {
 			data: message,
 		};
 
-		let conversationId: string;
-		let thread: Thread;
-
-		if (existingConversationId) {
-			const existingThread = await redisStore.get(existingConversationId);
-			if (existingThread) {
-				conversationId = existingConversationId;
-				thread = new Thread([...existingThread.events, userInputEvent]);
-			} else {
-				conversationId = randomUUID();
-				thread = new Thread([userInputEvent]);
-			}
-		} else {
-			conversationId = randomUUID();
-			thread = new Thread([userInputEvent]);
-		}
+		const { conversationId, thread } = await initializeConversation(
+			userInputEvent,
+			existingConversationId,
+			redisStore,
+		);
 
 		await redisStore.set(conversationId, thread);
       
@@ -166,6 +155,37 @@ export function createAgentRouter(deps: AgentDependencies): Router {
   });
 
 	return router;
+}
+
+/**
+ * Initialize or resume a conversation thread.
+ * Creates a new conversation if no existing ID is provided or if the thread is not found.
+ *
+ * @param userInputEvent - User input event to add to the thread
+ * @param existingConversationId - Optional existing conversation ID
+ * @param redisStore - Redis store for retrieving existing threads
+ * @returns Object containing conversationId and initialized thread
+ */
+async function initializeConversation(
+	userInputEvent: Event,
+	existingConversationId: string | undefined,
+	redisStore: RedisStateStore,
+): Promise<{ conversationId: string; thread: Thread }> {
+	if (existingConversationId) {
+		const existingThread = await redisStore.get(existingConversationId);
+		if (existingThread) {
+			return {
+				conversationId: existingConversationId,
+				thread: new Thread([...existingThread.events, userInputEvent]),
+			};
+		}
+	}
+
+	// Create new conversation if no existing ID or thread not found
+	return {
+		conversationId: randomUUID(),
+		thread: new Thread([userInputEvent]),
+	};
 }
 
 /**

--- a/packages/web/src/routes/agent.ts
+++ b/packages/web/src/routes/agent.ts
@@ -20,7 +20,9 @@ export interface AgentDependencies {
 	executor: NotionToolExecutor<NotionClient>;
 }
 
-const ConversationIdSchema = z.string().uuid().optional();
+// Accepts valid UUID strings, undefined, and null.
+// null and undefined both fall through to creating a new conversation.
+const ConversationIdSchema = z.string().uuid().nullish();
 
 /**
  * Create agent router with injected dependencies.

--- a/packages/web/src/routes/agent.ts
+++ b/packages/web/src/routes/agent.ts
@@ -20,6 +20,8 @@ export interface AgentDependencies {
 	executor: NotionToolExecutor<NotionClient>;
 }
 
+const ConversationIdSchema = z.string().uuid().optional();
+
 /**
  * Create agent router with injected dependencies.
  * Dependencies are captured in closure, avoiding global state.
@@ -45,7 +47,7 @@ export function createAgentRouter(deps: AgentDependencies): Router {
 				return;
 			}
 
-		const parsedConversationId = z.string().uuid().optional().safeParse(req.body.conversationId);
+		const parsedConversationId = ConversationIdSchema.safeParse(req.body.conversationId);
 		const existingConversationId = parsedConversationId.success ? parsedConversationId.data : undefined;
 
 		const userInputEvent: Event = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       redis:
         specifier: ^4.7.0
         version: 4.7.1
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@types/cors':
         specifier: ^2.8.17


### PR DESCRIPTION
## Summary

Closes #33

会話中に `done_for_now` やタスク完了後、エージェントが過去の会話履歴を失うバグを修正する。

- `POST /api/agent/query` でオプショナルな `conversationId` を受け取り、既存スレッドが Redis に存在する場合はそれに新メッセージを追記する
- フロントエンドのフックで `conversationId` をリクエストボディに含めるよう変更
- UI から後続メッセージ送信時に既存の `conversationId` を渡すよう修正

## Root Cause

Each `POST /api/agent/query` call always generated a new `conversationId` via `randomUUID()` and created an empty `Thread` with only the current message. The frontend stored `conversationId` in state but never passed it for follow-up messages.

## Test plan

- [x] 1回目のメッセージ送信後、同じ `conversationId` で2回目を送信できることを確認
- [x] エージェントが前の会話内容を踏まえた返答をすることを確認
- [x] `pnpm --filter @shochan_ai/web test` — 33テスト全パス
- [x] 存在しない `conversationId` が渡された場合、新規スレッドにフォールバックすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)