### PR TITLE
feat: タスク削除時にユーザー承認確認を追加

### DIFF
--- a/packages/web-ui/components/chat/approval-card.tsx
+++ b/packages/web-ui/components/chat/approval-card.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import type { ToolCall } from '@/types/chat';
+import { Button } from '@/components/ui/button';
+
+interface ApprovalCardProps {
+  toolCall: ToolCall;
+  onApprove: () => void;
+  onDeny: () => void;
+  isLoading?: boolean;
+}
+
+/**
+ * ApprovalCard - Displays a confirmation dialog for delete operations requiring human approval.
+ * Renders the tool call parameters and provides approve/deny buttons.
+ */
+export function ApprovalCard({ toolCall, onApprove, onDeny, isLoading = false }: ApprovalCardProps) {
+  return (
+    <div className="rounded-lg border border-red-200 bg-red-50 p-4 shadow-sm">
+      <div className="mb-3">
+        <h3 className="text-base font-semibold text-red-800">本当に削除しますか？</h3>
+        <p className="mt-1 text-sm text-red-600">この操作は取り消せません。</p>
+      </div>
+
+      <div className="mb-4 rounded-md bg-white p-3 border border-red-100">
+        <p className="text-xs font-medium text-gray-500 mb-1">操作の詳細</p>
+        <div className="space-y-1">
+          {Object.entries(toolCall.parameters).map(([key, value]) => (
+            <div key={key} className="flex gap-2 text-sm">
+              <span className="font-medium text-gray-600 min-w-24">{key}:</span>
+              <span className="text-gray-800 break-all">{String(value)}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex gap-2 justify-end">
+        <Button
+          variant="outline"
+          onClick={onDeny}
+          disabled={isLoading}
+          className="border-gray-300 text-gray-700 hover:bg-gray-100"
+        >
+          キャンセル
+        </Button>
+        <Button
+          onClick={onApprove}
+          disabled={isLoading}
+          className="bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
+        >
+          {isLoading ? '処理中...' : '削除する'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web-ui/components/chat/chat-interface.tsx
+++ b/packages/web-ui/components/chat/chat-interface.tsx
@@ -7,11 +7,14 @@ import { useSSE } from '@/hooks/use-sse'
 import { useAutoScroll } from '@/hooks/use-auto-scroll'
 import { MessageList } from './message-list'
 import { MessageInput } from './message-input'
+import { ApprovalCard } from './approval-card'
 import { Badge } from '@/components/ui/badge'
 
 export function ChatInterface() {
   const [messages, setMessages] = useState<Message[]>([])
   const [conversationId, setConversationId] = useState<string | null>(null)
+  const [pendingApproval, setPendingApproval] = useState<ToolCall | null>(null)
+  const [isApproving, setIsApproving] = useState(false)
 
   const mutation = useSendMessage({
     onSuccess: (data) => {
@@ -96,6 +99,10 @@ export function ChatInterface() {
         message = createCompleteMessage(event)
         break
 
+      case 'awaiting_approval':
+        setPendingApproval(event.data)
+        return
+
       case 'error':
         message = createErrorMessage(event)
         break
@@ -105,6 +112,29 @@ export function ChatInterface() {
       setMessages((prev) => [...prev, message])
     }
   }, [])
+
+  const handleApproval = useCallback(
+    async (approved: boolean) => {
+      if (!conversationId) return
+
+      setIsApproving(true)
+      try {
+        const apiUrl = process.env.NEXT_PUBLIC_API_URL
+        const response = await fetch(`${apiUrl}/api/agent/approve/${conversationId}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ approved }),
+        })
+        if (!response.ok) {
+          throw new Error('Failed to send approval')
+        }
+      } finally {
+        setPendingApproval(null)
+        setIsApproving(false)
+      }
+    },
+    [conversationId],
+  )
 
   useSSE(conversationId, handleSSEEvent)
 
@@ -137,7 +167,17 @@ export function ChatInterface() {
 
       <div className="fixed bottom-0 left-0 right-0 bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60 border-t p-4">
         <div className="max-w-4xl mx-auto">
-          <MessageInput onSend={handleSendMessage} disabled={mutation.isPending} />
+          {pendingApproval && (
+            <div className="mb-4">
+              <ApprovalCard
+                toolCall={pendingApproval}
+                onApprove={() => handleApproval(true)}
+                onDeny={() => handleApproval(false)}
+                isLoading={isApproving}
+              />
+            </div>
+          )}
+          <MessageInput onSend={handleSendMessage} disabled={mutation.isPending || isApproving} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 概要

タスクの削除をAIが提案した際、チャット内でユーザーに「削除して良いか？」を確認するUIを追加。

## 変更内容

### 新規ファイル
- `packages/web-ui/components/chat/approval-card.tsx` - 削除確認カードコンポーネント
  - 削除対象の情報（task_id等）を表示
  - 「削除する」（赤系）と「キャンセル」ボタン
  - 処理中はボタンをdisabled

### 修正ファイル
- `packages/web-ui/components/chat/chat-interface.tsx`
  - `awaiting_approval` SSEイベントを受信して `pendingApproval` 状態にセット
  - `handleApproval(approved: boolean)` 関数でバックエンドの `POST /api/agent/approve/:conversationId` を呼び出し
  - `ApprovalCard` を入力欄の上に表示
  - 承認処理中は入力欄をdisabled

## 動作フロー

1. ユーザーがタスク削除を依頼
2. AIが `delete_task` ツールを提案
3. バックエンドが `awaiting_approval` イベントをSSEで送信
4. チャット画面に承認確認カードが表示される
5. ユーザーが「削除する」→ タスク削除実行 / 「キャンセル」→ 削除中止

## バックエンド

バックエンド（CLI・Webサーバー）の承認フローは実装済み。今回はフロントエンドのみ変更。