### PR TITLE
feat: add get_projects and get_project_details tools

### DIFF
--- a/packages/client/src/notion.ts
+++ b/packages/client/src/notion.ts
@@ -1,10 +1,11 @@
 import { Client } from '@notionhq/client';
 import type { UpdatePageParameters } from '@notionhq/client/build/src/api-endpoints';
-import type { ProjectInfo, ToolCall } from '@shochan_ai/core';
+import type { ProjectDetails, ProjectInfo, ToolCall } from '@shochan_ai/core';
 import {
   isCreateProjectTool,
   isCreateTaskTool,
   isDeleteTaskTool,
+  isGetProjectDetailsTool,
   isGetProjectsTool,
   isGetTaskDetailsTool,
   isGetTasksTool,
@@ -384,6 +385,150 @@ export class NotionClient {
         `Failed to get task details: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
     }
+  }
+
+  async getProjectDetails(tool: ToolCall): Promise<ProjectDetails> {
+    if (!isGetProjectDetailsTool(tool)) {
+      throw new Error('Invalid tool call');
+    }
+
+    const { project_id } = tool.parameters;
+
+    try {
+      console.log(`🔍 [NOTION] Getting project details for ${project_id}`);
+
+      const pageResponse = await this.client.pages.retrieve({
+        page_id: project_id,
+      });
+
+      if (!this.taskParser.isFullPageResponse(pageResponse)) {
+        throw new Error(
+          'Notion returned a partial page response. Ensure the integration has access to the page/database.'
+        );
+      }
+
+      const properties = pageResponse.properties;
+
+      const name = this.extractTextFromProperty(properties, 'name') || 'Untitled Project';
+      const description = this.extractTextFromProperty(properties, 'description');
+      const importance = this.extractSelectFromProperty(properties, 'importance');
+      const status = this.extractStatusFromProperty(properties, 'status');
+      const action_plan = this.extractTextFromProperty(properties, 'action_plan');
+
+      let page_content: string | undefined;
+      try {
+        console.log(`🔍 [NOTION] Getting page content for project ${project_id}`);
+        const blocksResponse = await this.client.blocks.children.list({
+          block_id: project_id,
+          page_size: 100,
+        });
+        page_content = this.taskParser.parseContentFromBlocks(blocksResponse.results);
+        console.log(`✅ [NOTION] Project page content retrieved for ${project_id}`);
+      } catch (contentError) {
+        console.warn(`⚠️ [NOTION] Could not retrieve page content for ${project_id}:`, contentError);
+        page_content = undefined;
+      }
+
+      console.log(`🔍 [NOTION] Getting related tasks for project ${project_id}`);
+      const tasksResponse = await this.client.databases.query({
+        database_id: this.tasksDbId,
+        filter: {
+          property: 'project',
+          relation: {
+            contains: project_id,
+          },
+        },
+        page_size: 100,
+      });
+
+      const related_tasks = await this.taskParser.parseTasksFromNotionResponse(
+        tasksResponse.results
+      );
+      console.log(
+        `✅ [NOTION] Found ${related_tasks.length} related tasks for project ${project_id}`
+      );
+
+      return {
+        project_id: pageResponse.id,
+        name,
+        description,
+        importance,
+        status,
+        action_plan,
+        notion_url: pageResponse.url,
+        page_content,
+        related_tasks,
+        created_at: new Date(pageResponse.created_time),
+        updated_at: new Date(pageResponse.last_edited_time),
+      };
+    } catch (error) {
+      console.error('❌ [NOTION] Get project details failed:', error);
+
+      if (error instanceof Error && error.message.includes('Could not find page')) {
+        throw new Error(`Project with ID ${project_id} not found`);
+      }
+
+      if (error instanceof Error && error.message.includes('unauthorized')) {
+        throw new Error(`Access denied to project ${project_id}. Check integration permissions.`);
+      }
+
+      throw new Error(
+        `Failed to get project details: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  private extractTextFromProperty(
+    properties: Record<string, unknown>,
+    propertyName: string
+  ): string | undefined {
+    const prop = properties[propertyName];
+    if (!prop || typeof prop !== 'object' || prop === null) return undefined;
+
+    const propObj = prop as Record<string, unknown>;
+
+    if (propObj.type === 'title' && Array.isArray(propObj.title) && propObj.title.length > 0) {
+      const first = propObj.title[0] as { plain_text?: string };
+      return first.plain_text;
+    }
+    if (
+      propObj.type === 'rich_text' &&
+      Array.isArray(propObj.rich_text) &&
+      propObj.rich_text.length > 0
+    ) {
+      const first = propObj.rich_text[0] as { plain_text?: string };
+      return first.plain_text;
+    }
+
+    return undefined;
+  }
+
+  private extractSelectFromProperty(
+    properties: Record<string, unknown>,
+    propertyName: string
+  ): string | undefined {
+    const prop = properties[propertyName];
+    if (!prop || typeof prop !== 'object' || prop === null) return undefined;
+
+    const propObj = prop as Record<string, unknown>;
+    if (propObj.type !== 'select') return undefined;
+
+    const select = propObj.select as { name?: string } | null;
+    return select?.name;
+  }
+
+  private extractStatusFromProperty(
+    properties: Record<string, unknown>,
+    propertyName: string
+  ): string | undefined {
+    const prop = properties[propertyName];
+    if (!prop || typeof prop !== 'object' || prop === null) return undefined;
+
+    const propObj = prop as Record<string, unknown>;
+    if (propObj.type !== 'status') return undefined;
+
+    const status = propObj.status as { name?: string } | null;
+    return status?.name;
   }
 
   async testConnection(): Promise<boolean> {

--- a/packages/client/src/notion.ts
+++ b/packages/client/src/notion.ts
@@ -1,10 +1,11 @@
 import { Client } from '@notionhq/client';
 import type { UpdatePageParameters } from '@notionhq/client/build/src/api-endpoints';
-import type { ToolCall } from '@shochan_ai/core';
+import type { ProjectInfo, ToolCall } from '@shochan_ai/core';
 import {
   isCreateProjectTool,
   isCreateTaskTool,
   isDeleteTaskTool,
+  isGetProjectsTool,
   isGetTaskDetailsTool,
   isGetTasksTool,
   isUpdateTaskTool,
@@ -15,6 +16,7 @@ import {
   buildProjectCreatePageParams,
   buildTaskCreatePageParams,
   buildTaskUpdatePageParams,
+  parseProjectFromNotionPage,
 } from './notionUtils';
 
 export class NotionClient {
@@ -173,6 +175,82 @@ export class NotionClient {
       console.error('❌ [NOTION] Get tasks failed:', error);
       throw new Error(
         `Failed to get tasks: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  async getProjects(tool: ToolCall): Promise<{
+    projects: ProjectInfo[];
+    total_count: number;
+    has_more: boolean;
+    query_parameters: ToolCall['parameters'];
+  }> {
+    if (!isGetProjectsTool(tool)) {
+      throw new Error('Invalid tool call');
+    }
+
+    const { search_name, status, limit = 10 } = tool.parameters;
+
+    try {
+      console.log(`🔍 [NOTION] Getting projects with filters:`, tool.parameters);
+
+      // Build filters
+      type NotionFilter =
+        | { property: string; title: { contains: string } }
+        | { property: string; status: { equals: string } };
+
+      const notionFilters: NotionFilter[] = [];
+
+      if (search_name) {
+        notionFilters.push({
+          property: 'name',
+          title: { contains: search_name },
+        });
+      }
+
+      if (status) {
+        notionFilters.push({
+          property: 'status',
+          status: { equals: status },
+        });
+      }
+
+      const filter =
+        notionFilters.length > 0
+          ? notionFilters.length === 1
+            ? notionFilters[0]
+            : { and: notionFilters }
+          : undefined;
+
+      const response = await this.client.databases.query({
+        database_id: this.projectsDbId,
+        filter,
+        page_size: Math.min(limit, 100), // Notion API limit
+      });
+
+      const projects: ProjectInfo[] = [];
+      for (const result of response.results) {
+        if (!this.taskParser.isFullPageResponse(result)) continue;
+        try {
+          const project = parseProjectFromNotionPage(result);
+          projects.push(project);
+        } catch (parseError) {
+          console.warn(`Failed to parse project ${result.id}:`, parseError);
+        }
+      }
+
+      console.log(`✅ [NOTION] Found ${projects.length} projects`);
+
+      return {
+        projects,
+        total_count: projects.length,
+        has_more: response.has_more,
+        query_parameters: tool.parameters,
+      };
+    } catch (error) {
+      console.error('❌ [NOTION] Get projects failed:', error);
+      throw new Error(
+        `Failed to get projects: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
     }
   }

--- a/packages/client/src/notionUtils.ts
+++ b/packages/client/src/notionUtils.ts
@@ -4,7 +4,9 @@ import type {
   BuildTaskUpdatePageParamsArgs,
   NotionCreatePageParams,
   NotionUpdatePageParams,
+  ProjectInfo,
 } from '@shochan_ai/core';
+import type { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 
 type NotionPropertyUpdates = NotionUpdatePageParams['properties'];
 
@@ -201,4 +203,79 @@ export function buildTaskUpdatePageParams(
     page_id: pageId,
     properties,
   };
+}
+
+/**
+ * Parse a Notion page response into a ProjectInfo object.
+ */
+export function parseProjectFromNotionPage(page: PageObjectResponse): ProjectInfo {
+  const properties = page.properties;
+
+  const name = extractTextFromProperty(properties, 'name') || 'Untitled Project';
+  const description = extractRichTextFromProperty(properties, 'description');
+  const importance = extractSelectFromProperty(properties, 'importance');
+  const status = extractStatusFromProperty(properties, 'status');
+  const action_plan = extractRichTextFromProperty(properties, 'action_plan');
+
+  return {
+    project_id: page.id,
+    name,
+    description,
+    importance,
+    status,
+    action_plan,
+    notion_url: page.url,
+    created_at: new Date(page.created_time),
+    updated_at: new Date(page.last_edited_time),
+  };
+}
+
+// ===== Private helper functions for property extraction =====
+
+function extractTextFromProperty(
+  properties: PageObjectResponse['properties'],
+  propertyName: string
+): string | undefined {
+  const prop = properties[propertyName];
+  if (!prop) return undefined;
+
+  if (prop.type === 'title' && prop.title.length > 0) {
+    return prop.title[0].plain_text;
+  }
+
+  return undefined;
+}
+
+function extractRichTextFromProperty(
+  properties: PageObjectResponse['properties'],
+  propertyName: string
+): string | undefined {
+  const prop = properties[propertyName];
+  if (!prop) return undefined;
+
+  if (prop.type === 'rich_text' && prop.rich_text.length > 0) {
+    return prop.rich_text[0].plain_text;
+  }
+
+  return undefined;
+}
+
+function extractSelectFromProperty(
+  properties: PageObjectResponse['properties'],
+  propertyName: string
+): string | undefined {
+  const prop = properties[propertyName];
+  if (!prop || prop.type !== 'select') return undefined;
+
+  return prop.select?.name;
+}
+
+function extractStatusFromProperty(
+  properties: PageObjectResponse['properties'],
+  propertyName: string
+): string | undefined {
+  const prop = properties[propertyName];
+  if (!prop || prop.type !== 'status') return undefined;
+
+  return prop.status?.name;
 }

--- a/packages/core/src/agent/notion-tool-executor.ts
+++ b/packages/core/src/agent/notion-tool-executor.ts
@@ -12,6 +12,8 @@ import type { ToolExecutionResult, ToolExecutor } from './tool-executor';
  * - delete_task
  * - get_tasks
  * - get_task_details
+ * - get_projects
+ * - get_project_details
  *
  * Non-Notion tools (done_for_now, request_more_information) return
  * appropriate events without calling external APIs.
@@ -26,6 +28,8 @@ export class NotionToolExecutor<
     deleteTask(toolCall: ToolCall): Promise<unknown>;
     updateTask(toolCall: ToolCall): Promise<unknown>;
     getTaskDetails(toolCall: ToolCall): Promise<unknown>;
+    getProjects(toolCall: ToolCall): Promise<unknown>;
+    getProjectDetails(toolCall: ToolCall): Promise<unknown>;
   },
 > implements ToolExecutor
 {
@@ -40,7 +44,7 @@ export class NotionToolExecutor<
    * Executes a tool call and returns the result as an event.
    *
    * This method handles all tool types:
-   * - Notion API calls: create_task, create_project, update_task, delete_task, get_tasks, get_task_details
+   * - Notion API calls: create_task, create_project, update_task, delete_task, get_tasks, get_task_details, get_projects, get_project_details
    * - Control flow tools: done_for_now, request_more_information
    *
    * All errors are caught and returned as error events, ensuring the method never throws.
@@ -86,6 +90,10 @@ export class NotionToolExecutor<
         return await this.notionClient.updateTask(toolCall);
       case 'get_task_details':
         return await this.notionClient.getTaskDetails(toolCall);
+      case 'get_projects':
+        return await this.notionClient.getProjects(toolCall);
+      case 'get_project_details':
+        return await this.notionClient.getProjectDetails(toolCall);
       default:
         // TypeScript should ensure this is never reached due to exhaustive switch
         throw new Error(`Unknown tool intent: ${(toolCall as ToolCall).intent}`);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,13 +46,14 @@ export type {
   NotionCreatePageParams,
   NotionUpdatePageParams,
 } from './types/notion';
-export type { TaskInfo } from './types/task';
+export type { ProjectInfo, TaskInfo } from './types/task';
 // Type Guards
 export {
   isCreateProjectTool,
   isCreateTaskTool,
   isDeleteTaskTool,
   isDoneForNowTool,
+  isGetProjectsTool,
   isGetTaskDetailsTool,
   isGetTasksTool,
   isRequestMoreInformationTool,
@@ -63,6 +64,7 @@ export type {
   CreateTaskTool,
   DeleteTaskTool,
   DoneForNowTool,
+  GetProjectsTool,
   GetTaskDetailsTool,
   GetTasksTool,
   Importance,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,13 +46,14 @@ export type {
   NotionCreatePageParams,
   NotionUpdatePageParams,
 } from './types/notion';
-export type { ProjectInfo, TaskInfo } from './types/task';
+export type { ProjectDetails, ProjectInfo, TaskInfo } from './types/task';
 // Type Guards
 export {
   isCreateProjectTool,
   isCreateTaskTool,
   isDeleteTaskTool,
   isDoneForNowTool,
+  isGetProjectDetailsTool,
   isGetProjectsTool,
   isGetTaskDetailsTool,
   isGetTasksTool,
@@ -64,6 +65,7 @@ export type {
   CreateTaskTool,
   DeleteTaskTool,
   DoneForNowTool,
+  GetProjectDetailsTool,
   GetProjectsTool,
   GetTaskDetailsTool,
   GetTasksTool,

--- a/packages/core/src/tools/task-agent-tools.ts
+++ b/packages/core/src/tools/task-agent-tools.ts
@@ -170,6 +170,46 @@ export const taskAgentTools: OpenAI.Responses.FunctionTool[] = [
   },
   {
     type: 'function',
+    name: 'get_projects',
+    description: 'Retrieve a list of projects with optional filtering',
+    strict: null,
+    parameters: {
+      type: 'object',
+      properties: {
+        search_name: {
+          type: 'string',
+          description: 'Search projects by name (partial match)',
+        },
+        status: {
+          type: 'string',
+          description: 'Filter by project status',
+        },
+        limit: {
+          type: 'number',
+          minimum: 1,
+          maximum: 100,
+          description: 'Maximum number of projects to return (default: 10)',
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    type: 'function',
+    name: 'get_project_details',
+    description:
+      'Get detailed information about a specific project by its ID, including related tasks and page content',
+    strict: null,
+    parameters: {
+      type: 'object',
+      properties: {
+        project_id: { type: 'string', description: 'ID of the project to retrieve details for' },
+      },
+      required: ['project_id'],
+    },
+  },
+  {
+    type: 'function',
     name: 'request_more_information',
     description:
       'Use ONLY when you need additional information from the user to complete their request. Do not use for simple greetings or acknowledgments.',

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -24,3 +24,17 @@ export interface ProjectInfo {
   created_at: Date;
   updated_at: Date;
 }
+
+export interface ProjectDetails {
+  project_id: string;
+  name: string;
+  description?: string;
+  importance?: string;
+  status?: string;
+  action_plan?: string;
+  notion_url?: string;
+  page_content?: string;
+  related_tasks: TaskInfo[];
+  created_at: Date;
+  updated_at: Date;
+}

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -12,3 +12,15 @@ export interface TaskInfo {
   status: 'active' | 'completed' | 'archived';
   content?: string;
 }
+
+export interface ProjectInfo {
+  project_id: string;
+  name: string;
+  description?: string;
+  importance?: string;
+  status?: string;
+  action_plan?: string;
+  notion_url?: string;
+  created_at: Date;
+  updated_at: Date;
+}

--- a/packages/core/src/types/toolGuards.ts
+++ b/packages/core/src/types/toolGuards.ts
@@ -3,6 +3,7 @@ import type {
   CreateTaskTool,
   DeleteTaskTool,
   DoneForNowTool,
+  GetProjectsTool,
   GetTaskDetailsTool,
   GetTasksTool,
   RequestMoreInformationTool,
@@ -20,6 +21,10 @@ export function isCreateProjectTool(tool: ToolCall): tool is CreateProjectTool {
 
 export function isGetTasksTool(tool: ToolCall): tool is GetTasksTool {
   return tool.intent === 'get_tasks';
+}
+
+export function isGetProjectsTool(tool: ToolCall): tool is GetProjectsTool {
+  return tool.intent === 'get_projects';
 }
 
 export function isDeleteTaskTool(tool: ToolCall): tool is DeleteTaskTool {

--- a/packages/core/src/types/toolGuards.ts
+++ b/packages/core/src/types/toolGuards.ts
@@ -3,6 +3,7 @@ import type {
   CreateTaskTool,
   DeleteTaskTool,
   DoneForNowTool,
+  GetProjectDetailsTool,
   GetProjectsTool,
   GetTaskDetailsTool,
   GetTasksTool,
@@ -37,6 +38,10 @@ export function isUpdateTaskTool(tool: ToolCall): tool is UpdateTaskTool {
 
 export function isGetTaskDetailsTool(tool: ToolCall): tool is GetTaskDetailsTool {
   return tool.intent === 'get_task_details';
+}
+
+export function isGetProjectDetailsTool(tool: ToolCall): tool is GetProjectDetailsTool {
+  return tool.intent === 'get_project_details';
 }
 
 export function isRequestMoreInformationTool(tool: ToolCall): tool is RequestMoreInformationTool {

--- a/packages/core/src/types/tools.ts
+++ b/packages/core/src/types/tools.ts
@@ -87,6 +87,13 @@ export const getTaskDetailsSchema = z.object({
   }),
 });
 
+export const getProjectDetailsSchema = z.object({
+  intent: z.literal('get_project_details'),
+  parameters: z.object({
+    project_id: z.string(),
+  }),
+});
+
 export const requestMoreInformationSchema = z.object({
   intent: z.literal('request_more_information'),
   parameters: z.object({}),
@@ -109,6 +116,7 @@ export const toolCallSchema = z.discriminatedUnion('intent', [
   deleteTaskSchema,
   updateTaskSchema,
   getTaskDetailsSchema,
+  getProjectDetailsSchema,
   requestMoreInformationSchema,
   doneForNowSchema,
 ]);
@@ -124,6 +132,7 @@ export type GetProjectsTool = z.infer<typeof getProjectsSchema>;
 export type DeleteTaskTool = z.infer<typeof deleteTaskSchema>;
 export type UpdateTaskTool = z.infer<typeof updateTaskSchema>;
 export type GetTaskDetailsTool = z.infer<typeof getTaskDetailsSchema>;
+export type GetProjectDetailsTool = z.infer<typeof getProjectDetailsSchema>;
 export type RequestMoreInformationTool = z.infer<typeof requestMoreInformationSchema>;
 export type DoneForNowTool = z.infer<typeof doneForNowSchema>;
 

--- a/packages/core/src/types/tools.ts
+++ b/packages/core/src/types/tools.ts
@@ -51,6 +51,15 @@ export const getTasksSchema = z.object({
   }),
 });
 
+export const getProjectsSchema = z.object({
+  intent: z.literal('get_projects'),
+  parameters: z.object({
+    search_name: z.string().optional(),
+    status: z.string().optional(),
+    limit: z.number().optional().default(10),
+  }),
+});
+
 export const deleteTaskSchema = z.object({
   intent: z.literal('delete_task'),
   parameters: z.object({
@@ -96,6 +105,7 @@ export const toolCallSchema = z.discriminatedUnion('intent', [
   createTaskSchema,
   createProjectSchema,
   getTasksSchema,
+  getProjectsSchema,
   deleteTaskSchema,
   updateTaskSchema,
   getTaskDetailsSchema,
@@ -110,6 +120,7 @@ export type Importance = z.infer<typeof importanceSchema>;
 export type CreateTaskTool = z.infer<typeof createTaskSchema>;
 export type CreateProjectTool = z.infer<typeof createProjectSchema>;
 export type GetTasksTool = z.infer<typeof getTasksSchema>;
+export type GetProjectsTool = z.infer<typeof getProjectsSchema>;
 export type DeleteTaskTool = z.infer<typeof deleteTaskSchema>;
 export type UpdateTaskTool = z.infer<typeof updateTaskSchema>;
 export type GetTaskDetailsTool = z.infer<typeof getTaskDetailsSchema>;

--- a/packages/web-ui/components/chat/chat-interface.tsx
+++ b/packages/web-ui/components/chat/chat-interface.tsx
@@ -151,6 +151,8 @@ const TOOL_CALL_LABELS: Record<ToolCall['intent'], string> = {
   create_project: '📁 Creating project...',
   update_task: '✏️ Updating task...',
   delete_task: '🗑️ Confirming task deletion...',
+  get_projects: '🔍 Fetching project list...',
+  get_project_details: '🔍 Fetching project details...',
   request_more_information: '❓ Requesting more information...',
   done_for_now: '✅ Done',
 }


### PR DESCRIPTION
## Summary

- `get_projects` ツールを追加：Notionからプロジェクト一覧を取得（名前・ステータスでフィルタ可能）
- `get_project_details` ツールを追加：プロジェクト詳細（Notionページ本文 + 関連タスク一覧）を取得
- 両ツールをOpenAI tool definitions と notion-tool-executor に登録

## 変更ファイル

### packages/core
- `src/types/task.ts` - `ProjectInfo`, `ProjectDetails` インターフェース追加
- `src/types/tools.ts` - `GetProjectsTool`, `GetProjectDetailsTool` Zodスキーマ追加
- `src/types/toolGuards.ts` - 対応する型ガード追加
- `src/tools/task-agent-tools.ts` - OpenAI tool定義追加
- `src/agent/notion-tool-executor.ts` - ツール実行ハンドラ追加
- `src/index.ts` - 新型・型ガードをエクスポート

### packages/client
- `src/notion.ts` - `getProjects()`, `getProjectDetails()` メソッド追加
- `src/notionUtils.ts` - プロジェクトパーサー関数追加

### packages/web-ui
- `components/chat/chat-interface.tsx` - 新ツールのUIラベル追加

## Test plan

- [ ] `pnpm build` が全パッケージでエラーなく完了すること
- [ ] `get_projects` でプロジェクト一覧が取得できること
- [ ] `get_project_details` でプロジェクト詳細とページ本文・関連タスクが取得できること
- [ ] フィルタ（search_name, status）が正しく動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)